### PR TITLE
[SETTING] SwiftUI PreviewProvider 추가

### DIFF
--- a/Havit/Havit.xcodeproj/project.pbxproj
+++ b/Havit/Havit.xcodeproj/project.pbxproj
@@ -75,12 +75,13 @@
 		ED443F78278B59EF0059DE76 /* UIApplication+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443F77278B59EF0059DE76 /* UIApplication+Extension.swift */; };
 		ED443F7A278B61590059DE76 /* UITableView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443F79278B61590059DE76 /* UITableView+Extension.swift */; };
 		ED443F7C278B63190059DE76 /* UICollectionView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443F7B278B63190059DE76 /* UICollectionView+Extension.swift */; };
-		ED443F8A278C4D710059DE76 /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443F89278C4D710059DE76 /* NSObject+Extension.swift */; };
-		ED443F8D278C51DF0059DE76 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443F8C278C51DF0059DE76 /* Logger.swift */; };
 		ED443F7E278B6B180059DE76 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443F7D278B6B180059DE76 /* Coordinator.swift */; };
 		ED443F80278B6BC90059DE76 /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443F7F278B6BC90059DE76 /* BaseCoordinator.swift */; };
 		ED443F85278B6D3A0059DE76 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443F84278B6D3A0059DE76 /* AppCoordinator.swift */; };
 		ED443F87278B6D5E0059DE76 /* MainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443F86278B6D5E0059DE76 /* MainCoordinator.swift */; };
+		ED443F8A278C4D710059DE76 /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443F89278C4D710059DE76 /* NSObject+Extension.swift */; };
+		ED443F8D278C51DF0059DE76 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443F8C278C51DF0059DE76 /* Logger.swift */; };
+		EDDE0965278EA9CC0093B83F /* PreviewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDE0964278EA9CC0093B83F /* PreviewProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -151,12 +152,13 @@
 		ED443F77278B59EF0059DE76 /* UIApplication+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extension.swift"; sourceTree = "<group>"; };
 		ED443F79278B61590059DE76 /* UITableView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Extension.swift"; sourceTree = "<group>"; };
 		ED443F7B278B63190059DE76 /* UICollectionView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Extension.swift"; sourceTree = "<group>"; };
-		ED443F89278C4D710059DE76 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
-		ED443F8C278C51DF0059DE76 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		ED443F7D278B6B180059DE76 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		ED443F7F278B6BC90059DE76 /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
 		ED443F84278B6D3A0059DE76 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		ED443F86278B6D5E0059DE76 /* MainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
+		ED443F89278C4D710059DE76 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
+		ED443F8C278C51DF0059DE76 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		EDDE0964278EA9CC0093B83F /* PreviewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -617,14 +619,6 @@
 			path = Mock;
 			sourceTree = "<group>";
 		};
-		ED443F8B278C51BF0059DE76 /* Utils */ = {
-			isa = PBXGroup;
-			children = (
-				ED443F8C278C51DF0059DE76 /* Logger.swift */,
-			);
-			path = Utils;
-			sourceTree = "<group>";
-		};
 		ED443F83278B6C9D0059DE76 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
@@ -632,6 +626,15 @@
 				ED443F7F278B6BC90059DE76 /* BaseCoordinator.swift */,
 			);
 			path = Foundation;
+			sourceTree = "<group>";
+		};
+		ED443F8B278C51BF0059DE76 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				ED443F8C278C51DF0059DE76 /* Logger.swift */,
+				EDDE0964278EA9CC0093B83F /* PreviewProvider.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -827,6 +830,7 @@
 				ED443F252786A4310059DE76 /* MypageViewController.swift in Sources */,
 				ED443F192786A3450059DE76 /* CategoryContentsViewController.swift in Sources */,
 				ED443F212786A41B0059DE76 /* SocialLoginViewController.swift in Sources */,
+				EDDE0965278EA9CC0093B83F /* PreviewProvider.swift in Sources */,
 				ED443F78278B59EF0059DE76 /* UIApplication+Extension.swift in Sources */,
 				ED443F85278B6D3A0059DE76 /* AppCoordinator.swift in Sources */,
 				ED443F80278B6BC90059DE76 /* BaseCoordinator.swift in Sources */,

--- a/Havit/Havit/Global/Utils/PreviewProvider.swift
+++ b/Havit/Havit/Global/Utils/PreviewProvider.swift
@@ -1,0 +1,69 @@
+//
+//  PreviewProvider.swift
+//  Havit
+//
+//  Created by SHIN YOON AH on 2022/01/12.
+//
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+enum DeviceType {
+    case iPhone8
+    case iPhoneSE2
+    case iPhone12ProMax
+    case iPhone13Mini
+    case iPhone13Pro
+
+    func name() -> String {
+        switch self {
+        case .iPhone8:
+            return "iPhone 8"
+        case .iPhoneSE2:
+            return "iPhone SE (2nd generation)"
+        case .iPhone12ProMax:
+            return "iPhone 12 Pro Max"
+        case .iPhone13Mini:
+            return "iPhone 13 mini"
+        case .iPhone13Pro:
+            return "iPhone 13 Pro"
+        }
+    }
+}
+
+extension UIViewController {
+    private struct Preview: UIViewControllerRepresentable {
+        let viewController: UIViewController
+
+        func makeUIViewController(context: Context) -> UIViewController {
+            return viewController
+        }
+
+        func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+            
+        }
+    }
+
+    func showPreview(_ deviceType: DeviceType = .iPhone13Pro) -> some View {
+        Preview(viewController: self).previewDevice(PreviewDevice(rawValue: deviceType.name()))
+    }
+}
+
+extension UIView {
+    private struct Preview: UIViewRepresentable {
+        let view: UIView
+
+        func makeUIView(context: Context) -> UIView {
+            return view
+        }
+
+        func updateUIView(_ uiView: UIView, context: Context) {
+            
+        }
+    }
+
+    func showPreview(_ deviceType: DeviceType = .iPhone13Pro) -> some View {
+        Preview(view: self).previewDevice(PreviewDevice(rawValue: deviceType.name()))
+    }
+}
+#endif


### PR DESCRIPTION
## 🟣 관련 이슈

- close #23

## 🟣 구현/변경 사항 및 이유

SwiftUI에서 제공해주는 PreviewProvider를 추가했습니다.

## 🟣 PR Point

Preview를 사용하고자 하는 `ViewController`, `View`가 있다면
```swift

// ViewController의 Preview
#if canImport(SwiftUI) && DEBUG
import SwiftUI

struct Preview: PreviewProvider {
    static var previews: some View {
        MainViewController().showPreview(.iPhone13Mini)
        MainViewController().showPreview(.iPhone12ProMax)
    }
}
#endif

// View의 Preview
#if canImport(SwiftUI) && DEBUG
import SwiftUI

struct Preview: PreviewProvider {
    static var previews: some View {
        MyView().showPreview(.iPhone13Mini)
        MyView().showPreview(.iPhoneSE2)
    }
}
#endif
```
해당 코드를 하단에 넣어주시면 됩니다.
`static var previews: some View` 내부에는 하나의 ViewController, View뿐만 아니라 여러개의 기기로 Preview를 돌려볼 수 있습니다.

현재는 데모데이에 테스트를 진행하는 `iPhone 13 Pro`, `iPhone 13 mini`, `iPhone SE (2nd generation)` 뿐만아니라 `iPhone 8`, `iPhone 12 Pro Max`까지 넣어두었습니다. 해당 디바이스가 시뮬레이터에 다운로드되어 있어야만 Preview로 구동 가능합니다. 아니라면 default로 넣어둔 `iPhone 13 Pro`로 돌아갑니다.

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

https://user-images.githubusercontent.com/55099365/149076605-8b49c472-279b-4de8-931c-9f394dd1cb44.mov


https://ios-development.tistory.com/488 < 더 많은 내용은 해당 블로그에서 확인해주세요. 