### PR TITLE
[FEAT] WebView 기본 동작 구현 (load 및 delegate 처리)

### DIFF
--- a/Havit/Havit.xcodeproj/project.pbxproj
+++ b/Havit/Havit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3BBB51D4279062910098A835 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BBB51D3279062910098A835 /* WebKit.framework */; };
 		4D6F9E35278C8AA800EC074D /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4D6F9E2C278C8AA600EC074D /* Pretendard-ExtraBold.otf */; };
 		4D6F9E36278C8AA800EC074D /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4D6F9E2C278C8AA600EC074D /* Pretendard-ExtraBold.otf */; };
 		4D6F9E37278C8AA800EC074D /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4D6F9E2C278C8AA600EC074D /* Pretendard-ExtraBold.otf */; };
@@ -102,6 +103,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3BBB51D3279062910098A835 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		4D6F9E2C278C8AA600EC074D /* Pretendard-ExtraBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-ExtraBold.otf"; sourceTree = "<group>"; };
 		4D6F9E2D278C8AA700EC074D /* Pretendard-ExtraLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-ExtraLight.otf"; sourceTree = "<group>"; };
 		4D6F9E2E278C8AA700EC074D /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BBB51D4279062910098A835 /* WebKit.framework in Frameworks */,
 				ED443F3E2786B5840059DE76 /* RxCocoa in Frameworks */,
 				ED443F382786B32B0059DE76 /* SnapKit in Frameworks */,
 				ED443F402786B5840059DE76 /* RxSwift in Frameworks */,
@@ -190,6 +193,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3BBB51D2279062910098A835 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3BBB51D3279062910098A835 /* WebKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		ED443EA1278598670059DE76 = {
 			isa = PBXGroup;
 			children = (
@@ -198,6 +209,7 @@
 				ED443EC3278598690059DE76 /* HavitTests */,
 				ED443ECD278598690059DE76 /* HavitUITests */,
 				ED443EAB278598670059DE76 /* Products */,
+				3BBB51D2279062910098A835 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};

--- a/Havit/Havit.xcodeproj/project.pbxproj
+++ b/Havit/Havit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3BBB51D4279062910098A835 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BBB51D3279062910098A835 /* WebKit.framework */; };
+		3BBB51D6279085A40098A835 /* WebViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBB51D5279085A40098A835 /* WebViewCoordinator.swift */; };
 		4D6F9E35278C8AA800EC074D /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4D6F9E2C278C8AA600EC074D /* Pretendard-ExtraBold.otf */; };
 		4D6F9E36278C8AA800EC074D /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4D6F9E2C278C8AA600EC074D /* Pretendard-ExtraBold.otf */; };
 		4D6F9E37278C8AA800EC074D /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4D6F9E2C278C8AA600EC074D /* Pretendard-ExtraBold.otf */; };
@@ -104,6 +105,7 @@
 
 /* Begin PBXFileReference section */
 		3BBB51D3279062910098A835 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		3BBB51D5279085A40098A835 /* WebViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewCoordinator.swift; sourceTree = "<group>"; };
 		4D6F9E2C278C8AA600EC074D /* Pretendard-ExtraBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-ExtraBold.otf"; sourceTree = "<group>"; };
 		4D6F9E2D278C8AA700EC074D /* Pretendard-ExtraLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-ExtraLight.otf"; sourceTree = "<group>"; };
 		4D6F9E2E278C8AA700EC074D /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 				ED443F83278B6C9D0059DE76 /* Foundation */,
 				ED443F84278B6D3A0059DE76 /* AppCoordinator.swift */,
 				ED443F86278B6D5E0059DE76 /* MainCoordinator.swift */,
+				3BBB51D5279085A40098A835 /* WebViewCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -839,6 +842,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BBB51D6279085A40098A835 /* WebViewCoordinator.swift in Sources */,
 				ED443F482786BA0F0059DE76 /* UILabel+Extension.swift in Sources */,
 				ED443F292786A9260059DE76 /* GenericResponse.swift in Sources */,
 				ED443F2B2786A9500059DE76 /* NetworkStatus.swift in Sources */,

--- a/Havit/Havit/Coordinator/WebViewCoordinator.swift
+++ b/Havit/Havit/Coordinator/WebViewCoordinator.swift
@@ -1,0 +1,16 @@
+//
+//  WebViewCoordinator.swift
+//  Havit
+//
+//  Created by 강수진 on 2022/01/14.
+//
+
+import Foundation
+
+final class WebViewCoordinator: BaseCoordinator {
+    func start(with url: String) {
+        let webViewController = WebViewController(url: url)
+        webViewController.coordinator = self
+        navigationController.pushViewController(webViewController, animated: true)
+    }
+}

--- a/Havit/Havit/Global/Supports/Info.plist
+++ b/Havit/Havit/Global/Supports/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Black.otf</string>

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -57,7 +57,7 @@ final class WebViewController: BaseViewController {
 
 extension WebViewController: WKUIDelegate {
     func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {
-        let okAction = UIAlertAction(title: "확인", style: .default) { (_) in
+        let okAction = UIAlertAction(title: "확인", style: .default) { _ in
             completionHandler()
         }
         showAlert(with: message, alertActions: okAction)

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -36,5 +36,15 @@ final class WebViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        loadWebPage(with: url)
+    }
+    
+    // MARK: - func
+    private func loadWebPage(with url: String) {
+        guard let url = URL(string: url) else {
+            return
+        }
+        let urlRequest = URLRequest(url: url)
+        webView.load(urlRequest)
     }
 }

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -11,6 +11,7 @@ import WebKit
 final class WebViewController: BaseViewController {
     
     // MARK: - property
+    
     weak var coordinator: WebViewCoordinator?
     private let url: String
     private lazy var webView: WKWebView = {
@@ -21,6 +22,7 @@ final class WebViewController: BaseViewController {
     }()
     
     // MARK: - init
+    
     init(url: String) {
         self.url = url
         super.init()
@@ -32,6 +34,7 @@ final class WebViewController: BaseViewController {
     }
     
     // MARK: - life cycle
+    
     override func loadView() {
         view = webView
     }
@@ -42,6 +45,7 @@ final class WebViewController: BaseViewController {
     }
     
     // MARK: - func
+    
     private func loadWebPage(with url: String) {
         guard let url = URL(string: url) else {
             return

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -11,6 +11,7 @@ import WebKit
 final class WebViewController: BaseViewController {
     
     // MARK: - property
+    weak var coordinator: WebViewCoordinator?
     private let url: String
     private lazy var webView: WKWebView = {
         let webView = WKWebView()

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -5,4 +5,36 @@
 //  Created by SHIN YOON AH on 2022/01/06.
 //
 
-import Foundation
+import UIKit
+import WebKit
+
+final class WebViewController: BaseViewController {
+    
+    // MARK: - property
+    private let url: String
+    private lazy var webView: WKWebView = {
+        let webView = WKWebView()
+        webView.allowsBackForwardNavigationGestures = true
+        return webView
+    }()
+    
+    // MARK: - init
+    init(url: String) {
+        self.url = url
+        super.init()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - life cycle
+    override func loadView() {
+        view = webView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -15,6 +15,7 @@ final class WebViewController: BaseViewController {
     private lazy var webView: WKWebView = {
         let webView = WKWebView()
         webView.allowsBackForwardNavigationGestures = true
+        webView.uiDelegate = self
         return webView
     }()
     
@@ -46,5 +47,43 @@ final class WebViewController: BaseViewController {
         }
         let urlRequest = URLRequest(url: url)
         webView.load(urlRequest)
+    }
+}
+
+extension WebViewController: WKUIDelegate {
+    func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {
+        let okAction = UIAlertAction(title: "확인", style: .default) { (_) in
+            completionHandler()
+        }
+        showAlert(with: message, alertActions: okAction)
+    }
+
+    func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
+        let okAction = UIAlertAction(title: "확인", style: .default) { _ in
+            completionHandler(true)
+        }
+        let cancelAction = UIAlertAction(title: "취소", style: .default) { _ in
+            completionHandler(false)
+        }
+        showAlert(with: message, alertActions: okAction, cancelAction)
+    }
+    
+    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+        if let targetFrame = navigationAction.targetFrame,
+           targetFrame.isMainFrame {
+            return nil
+        }
+        
+        // href="_blank" 새 창 열기
+        webView.load(navigationAction.request)
+        return nil
+    }
+    
+    private func showAlert(with message: String, alertActions: UIAlertAction...) {
+        let alertController = UIAlertController(title: "", message: message, preferredStyle: .alert)
+        alertActions.forEach { alertAction in
+            alertController.addAction(alertAction)
+        }
+        self.present(alertController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
## 🟣 관련 이슈

- close #32

## 🟣 구현/변경 사항 및 이유

컨텐츠 보기를 위한 웹 뷰를 추가 했습니다

## 🟣 PR Point
- RX 적용을 해보려고 했지만, 구글링을 해봤을때 webView 관련해서는 나오는게 거의 없어서 적용하지 않았습니다.
- ViewModel 도 만들어 적용하려고 했는데 ViewController 에서 역할이 뷰 로드 및 딜리게이트 처리 후 alert 를 띄우는 정도라 분리가 애매한 것 같습니다 (정말 뷰에서 해야할 것만 남은 느낌,,???). 빼낼 수 있는 부분이 보인다면 의견 부탁드립니다.
- WKUIDelegate 를 통해 웹 뷰에서 alert panel 이 뜰 때와, `_blank` 로 새창이 떠야할때 정도만을 핸들링 했습니다. 모든 상황에 대해 핸들링하는 것은 불필요한 코드가 늘어나는 것 같아, QA 하면서 필요한 사항들에 대해 추가를 해야할 것 같습니다.
- Coordinator 쪽에서 parameter 를 넘겨받아야할 것 같아 `func start()` 를 override 해서 사용하지 않았습니다. 따라서 아래와 같이 사용할 수 없습니다. 자세한 사용법은 아래에 기재해 두었습니다.
```
    func goToWebView() {
        let coordinator = WebViewCoordinator(navigationController: navigationController)
        super.start(coordinator: coordinator)
    }
```
- commit 할때 [FEAT] 과 [ADD] 의 구분이 애매해서 그냥 느낌가는대로 써봤는데 보시다가 아니라면 말씀 부탁드립니다

## 🟣 참고 사항
다른 코디네이터에서 아래와 같이 접근할 수 있습니다
```swift
        let coordinator = WebViewCoordinator(navigationController: navigationController)
        coordinator.start(with: "https://www.google.com")
```

![image](https://user-images.githubusercontent.com/20410193/149369298-90d21363-742c-4a85-a19f-0b3cc83a4b2f.png)

