### PR TITLE
[FEAT] Webview header 작성

### DIFF
--- a/Havit/Havit/Coordinator/WebViewCoordinator.swift
+++ b/Havit/Havit/Coordinator/WebViewCoordinator.swift
@@ -13,8 +13,8 @@ final class WebViewCoordinator: BaseCoordinator {
         case previous
     }
     
-    func start(with url: String) {
-        let webViewController = WebViewController(url: url)
+    func start(with urlString: String) {
+        let webViewController = WebViewController(urlString: urlString)
         webViewController.coordinator = self
         navigationController.pushViewController(webViewController, animated: true)
     }

--- a/Havit/Havit/Coordinator/WebViewCoordinator.swift
+++ b/Havit/Havit/Coordinator/WebViewCoordinator.swift
@@ -8,9 +8,22 @@
 import Foundation
 
 final class WebViewCoordinator: BaseCoordinator {
+    
+    enum WebViewTransition {
+        case previous
+    }
+    
     func start(with url: String) {
         let webViewController = WebViewController(url: url)
         webViewController.coordinator = self
         navigationController.pushViewController(webViewController, animated: true)
+    }
+    
+    func performTransition(to transition: WebViewTransition) {
+        switch transition {
+        case .previous:
+            parentCoordinator?.didFinish(coordinator: self)
+            navigationController.popViewController(animated: true)
+        }
     }
 }

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -8,6 +8,9 @@
 import UIKit
 import WebKit
 
+import RxCocoa
+import RxSwift
+
 final class WebViewController: BaseViewController {
     
     // MARK: - property
@@ -75,6 +78,7 @@ final class WebViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        bind()
         loadWebPage(with: url)
     }
     
@@ -93,6 +97,28 @@ final class WebViewController: BaseViewController {
         navigationItem.leftBarButtonItem = leftBarButtonItem
         navigationItem.titleView = titleView
         navigationItem.rightBarButtonItem = rightBarButtonItem
+    }
+    
+    private func bind() {
+        urlTextField.rx
+            .controlEvent(.editingDidEndOnExit)
+            .compactMap { [weak self] _ -> String? in
+                self?.appendHttpPrefixIfNeeded(to: self?.urlTextField.text)
+            }
+            .subscribe { [weak self] url in
+                self?.loadWebPage(with: url)
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func appendHttpPrefixIfNeeded(to url: String?) -> String? {
+        guard var url = url else {
+            return nil
+        }
+        if !url.hasPrefix("http") {
+            url = "http://" + url
+        }
+        return url
     }
     
     private func loadWebPage(with url: String) {

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -51,6 +51,7 @@ final class WebViewController: BaseViewController {
         let webView = WKWebView()
         webView.allowsBackForwardNavigationGestures = true
         webView.uiDelegate = self
+        webView.navigationDelegate = self
         return webView
     }()
     
@@ -138,5 +139,15 @@ extension WebViewController: WKUIDelegate {
             alertController.addAction(alertAction)
         }
         self.present(alertController, animated: true, completion: nil)
+    }
+}
+
+extension WebViewController: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        setUrlTextFieldText(with: webView.url?.description)
+    }
+    
+    private func setUrlTextFieldText(with url: String?) {
+        urlTextField.text = url
     }
 }

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -13,6 +13,15 @@ import RxSwift
 
 final class WebViewController: BaseViewController {
     
+    enum Size {
+        static let urlTextFieldWidth: CGFloat = {
+            let viewWidth = UIScreen.main.bounds.width
+            let barButtonWidth: CGFloat = 44
+            return viewWidth - (barButtonWidth * 2)
+        }()
+        static let urlTextFieldHeight: CGFloat = 33
+    }
+    
     // MARK: - property
     
     weak var coordinator: WebViewCoordinator?
@@ -30,7 +39,8 @@ final class WebViewController: BaseViewController {
     private let urlTextField: UITextField = {
         let textField = UITextField()
         textField.frame = CGRect(origin: .zero,
-                                 size: CGSize(width: .max, height: 33))
+                                 size: CGSize(width: Size.urlTextFieldWidth,
+                                              height: Size.urlTextFieldHeight))
         textField.backgroundColor = .gray000
         textField.layer.cornerRadius = 4
         textField.font = .font(.pretendardReular, ofSize: 16)

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -16,7 +16,7 @@ final class WebViewController: BaseViewController {
     // MARK: - property
     
     weak var coordinator: WebViewCoordinator?
-    private let url: String
+    private let urlString: String
     
     private let navigationBackBarButton: UIBarButtonItem = {
         let backButtonImage = UIImage(named: "iconBackBlack")
@@ -60,8 +60,8 @@ final class WebViewController: BaseViewController {
     
     // MARK: - init
     
-    init(url: String) {
-        self.url = url
+    init(urlString: String) {
+        self.urlString = urlString
         super.init()
     }
 
@@ -79,7 +79,7 @@ final class WebViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         bind()
-        loadWebPage(with: url)
+        loadWebPage(with: urlString)
     }
     
     // MARK: - func
@@ -122,14 +122,14 @@ final class WebViewController: BaseViewController {
             .disposed(by: disposeBag)
     }
     
-    private func appendHttpPrefixIfNeeded(to url: String?) -> String? {
-        guard var url = url else {
+    private func appendHttpPrefixIfNeeded(to urlString: String?) -> String? {
+        guard var urlString = urlString else {
             return nil
         }
-        if !url.hasPrefix("http") {
-            url = "http://" + url
+        if !urlString.hasPrefix("http") {
+            urlString = "http://" + urlString
         }
-        return url
+        return urlString
     }
     
     private func loadWebPage(with urlString: String?) {

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -109,6 +109,13 @@ final class WebViewController: BaseViewController {
                 self?.loadWebPage(with: url)
             }
             .disposed(by: disposeBag)
+        
+        reloadUrlBarButton.rx
+            .tap
+            .subscribe { [weak self] _ in
+                self?.webView.reload()
+            }
+            .disposed(by: disposeBag)
     }
     
     private func appendHttpPrefixIfNeeded(to url: String?) -> String? {

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -100,6 +100,13 @@ final class WebViewController: BaseViewController {
     }
     
     private func bind() {
+        navigationBackBarButton.rx
+            .tap
+            .subscribe { [weak self] _ in
+                self?.coordinator?.performTransition(to: .previous)
+            }
+            .disposed(by: disposeBag)
+        
         urlTextField.rx
             .controlEvent(.editingDidEndOnExit)
             .compactMap { [weak self] _ -> String? in

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -122,6 +122,19 @@ final class WebViewController: BaseViewController {
             .disposed(by: disposeBag)
     }
     
+    private func loadWebPage(with urlString: String?) {
+        let isValidUrlString = urlString?.isValidURL ?? false
+        let validUrlString = isValidUrlString ? appendHttpPrefixIfNeeded(to: urlString) : getGoogleSearchUrl(withKeyword: urlString)
+        
+        guard let validUrlString = validUrlString,
+              let url = URL(string: validUrlString) else {
+            return
+        }
+        
+        let urlRequest = URLRequest(url: url)
+        webView.load(urlRequest)
+    }
+    
     private func appendHttpPrefixIfNeeded(to urlString: String?) -> String? {
         guard var urlString = urlString else {
             return nil
@@ -132,16 +145,9 @@ final class WebViewController: BaseViewController {
         return urlString
     }
     
-    private func loadWebPage(with urlString: String?) {
-        let urlString = appendHttpPrefixIfNeeded(to: urlString)
-        
-        guard let urlString = urlString,
-              let url = URL(string: urlString) else {
-            return
-        }
-        
-        let urlRequest = URLRequest(url: url)
-        webView.load(urlRequest)
+    private func getGoogleSearchUrl(withKeyword keyword: String?) -> String {
+        let googleSearchUrl = "https://www.google.com/search?q=\(keyword ?? "")"
+        return googleSearchUrl
     }
 }
 
@@ -190,5 +196,19 @@ extension WebViewController: WKNavigationDelegate {
     
     private func setUrlTextFieldText(with url: String?) {
         urlTextField.text = url
+    }
+}
+
+fileprivate extension String {
+    var isValidURL: Bool {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return false
+        }
+        if let match = detector.firstMatch(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count)) {
+            // it is a link, if the match covers the whole string
+            return match.range.length == self.utf16.count
+        } else {
+            return false
+        }
     }
 }

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -112,7 +112,7 @@ final class WebViewController: BaseViewController {
     private func bindInput() {
         navigationBackBarButton.rx
             .tap
-            .subscribe { [weak self] _ in
+            .bind { [weak self] _ in
                 self?.coordinator?.performTransition(to: .previous)
             }
             .disposed(by: disposeBag)

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -14,6 +14,39 @@ final class WebViewController: BaseViewController {
     
     weak var coordinator: WebViewCoordinator?
     private let url: String
+    
+    private let navigationBackBarButton: UIBarButtonItem = {
+        let backButtonImage = UIImage(named: "iconBackBlack")
+        let navigationBackBarButton = UIBarButtonItem(image: backButtonImage,
+                                                      style: .plain,
+                                                      target: nil,
+                                                      action: nil)
+        return navigationBackBarButton
+    }()
+    
+    private let urlTextField: UITextField = {
+        let textField = UITextField()
+        textField.frame = CGRect(origin: .zero,
+                                 size: CGSize(width: .max, height: 33))
+        textField.backgroundColor = .gray000
+        textField.layer.cornerRadius = 4
+        textField.font = .font(.pretendardReular, ofSize: 16)
+        textField.autocapitalizationType = .none
+        textField.autocorrectionType = .no
+        textField.spellCheckingType = .no
+        textField.keyboardType = .URL
+        return textField
+    }()
+    
+    private let reloadUrlBarButton: UIBarButtonItem = {
+        let reloadImage = UIImage(named: "iconRefresh")
+        let reloadUrlBarButton = UIBarButtonItem(image: reloadImage,
+                                                 style: .plain,
+                                                 target: nil,
+                                                 action: nil)
+        return reloadUrlBarButton
+    }()
+    
     private lazy var webView: WKWebView = {
         let webView = WKWebView()
         webView.allowsBackForwardNavigationGestures = true
@@ -45,6 +78,21 @@ final class WebViewController: BaseViewController {
     }
     
     // MARK: - func
+    
+    override func configUI() {
+        setupBaseNavigationBar()
+        setNavigationItem(leftBarButtonItem: navigationBackBarButton,
+                          titleView: urlTextField,
+                          rightBarButtonItem: reloadUrlBarButton)
+    }
+    
+    private func setNavigationItem(leftBarButtonItem: UIBarButtonItem,
+                                   titleView: UIView,
+                                   rightBarButtonItem: UIBarButtonItem) {
+        navigationItem.leftBarButtonItem = leftBarButtonItem
+        navigationItem.titleView = titleView
+        navigationItem.rightBarButtonItem = rightBarButtonItem
+    }
     
     private func loadWebPage(with url: String) {
         guard let url = URL(string: url) else {

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -109,11 +109,8 @@ final class WebViewController: BaseViewController {
         
         urlTextField.rx
             .controlEvent(.editingDidEndOnExit)
-            .compactMap { [weak self] _ -> String? in
-                self?.appendHttpPrefixIfNeeded(to: self?.urlTextField.text)
-            }
-            .subscribe { [weak self] url in
-                self?.loadWebPage(with: url)
+            .subscribe { [weak self] _ in
+                self?.loadWebPage(with: self?.urlTextField.text)
             }
             .disposed(by: disposeBag)
         
@@ -135,10 +132,14 @@ final class WebViewController: BaseViewController {
         return url
     }
     
-    private func loadWebPage(with url: String) {
-        guard let url = URL(string: url) else {
+    private func loadWebPage(with urlString: String?) {
+        let urlString = appendHttpPrefixIfNeeded(to: urlString)
+        
+        guard let urlString = urlString,
+              let url = URL(string: urlString) else {
             return
         }
+        
         let urlRequest = URLRequest(url: url)
         webView.load(urlRequest)
     }

--- a/Havit/Havit/Screens/WebView/ViewModel/WebViewModel.swift
+++ b/Havit/Havit/Screens/WebView/ViewModel/WebViewModel.swift
@@ -6,3 +6,61 @@
 //
 
 import Foundation
+
+import RxSwift
+
+final class WebViewModel {
+    
+    // MARK: - View -> ViewModel
+    
+    let urlString: BehaviorSubject<String?>
+    
+    // MARK: - ViewModel -> View
+    
+    var urlRequest: Observable<URLRequest>
+    
+    init(urlString: String) {
+        self.urlString = BehaviorSubject<String?>(value: urlString)
+        self.urlRequest = self.urlString
+            .compactMap { urlString -> String? in
+                let isValidUrlString = urlString?.isValidURL ?? false
+                let validUrlString = isValidUrlString ? appendHttpPrefixIfNeeded(to: urlString) : getGoogleSearchUrl(withKeyword: urlString)
+                return validUrlString
+            }
+            .compactMap {
+                URL(string: $0)
+            }
+            .compactMap {
+                URLRequest(url: $0)
+            }
+        
+        func appendHttpPrefixIfNeeded(to urlString: String?) -> String? {
+            guard var urlString = urlString else {
+                return nil
+            }
+            if !urlString.hasPrefix("http") {
+                urlString = "http://" + urlString
+            }
+            return urlString
+        }
+        
+        func getGoogleSearchUrl(withKeyword keyword: String?) -> String {
+            let googleSearchUrl = "https://www.google.com/search?q=\(keyword ?? "")"
+            return googleSearchUrl
+        }
+    }
+}
+
+fileprivate extension String {
+    var isValidURL: Bool {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return false
+        }
+        if let match = detector.firstMatch(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count)) {
+            // it is a link, if the match covers the whole string
+            return match.range.length == self.utf16.count
+        } else {
+            return false
+        }
+    }
+}


### PR DESCRIPTION
## 🟣 관련 이슈

- closed #36 

## 🟣 구현/변경 사항 및 이유
아래의 기능들이 가능한 Web View Header 를 구현했습니다
- [x] pop viewController
- [x]  urlTextField 에서 값 입력 후 return 시 웹 로드
  - [x] http 가 붙어있지 않은 url 일때 `"http://"` 추가
  - [x] 유효하지 않은 url 일때 기본 구글로 검색되도록 연결 
- [x] 로드 된 webView url 에 따라 urlTextField 값 변경
- [x] 새로 고침

## 🟣 PR Point

- #35 에서도 언급했지만 WebViewCoordinator 의 경우, start 를 할때 parameter 를 넘겨받아야 합니다. 이는 즉`func start()`를 override 한 후에 `super.start(coordinator: coordinator)` 처럼 사용하지 못함을 의미합니다. 
  따라서 아래와 같이 `childCoordinators` 와 `parentCoordinator` 에 대한 설정을 신경써서 별도로 처리해야합니다. 그렇지 않으면 coordinator 가 weak self 로 선언이 되어있기 때문에 제대로 할당이 되지 않는 이슈가 있었습니다. 이를 잊지 않고 항상 설정할 수 있도록 강제할 수 있는 방안이 필요해 보입니다. 이는 따로 이슈로 빼놓겠습니다. -> #53 
   ```swift
        let webCoordinator = WebViewCoordinator(navigationController: navigationController)
        childCoordinators.append(webCoordinator)
        webCoordinator.parentCoordinator = self
        webCoordinator.start(with: "www.naver.com")
   ```
- urlTextField 의 경우 rightBarButtonItem 과 leftBarButtonItem 과의 관계로 width 를 설정하는게 맞겠지만, UIBarButtonItem 에 대해서는 snapkit 이 지원하지 않아 barbutton item 의 width 인 44 * 2 만큼 전체 width 에서 빼는 식으로 width 를 구했습니다 
- BarButton 에 대한 이미지는 현재 develop 에 포함되지 않아 ImageLiteral 을 쓰지 않았습니다.
- `UIApplication.shared.canOpenUrl` 으로만 valid url 을 계산시, http:// 로 시작하면 모두 valid 하다고 판단해 (ex. `http://fff` ) 이슈가 있었습니다. 따라서 validUrl 을 계산하는 로직은 [해당 링크](https://stackoverflow.com/questions/28079123/how-to-check-validity-of-url-in-swift)를 참고했습니다


## 🟣 참고 사항


https://user-images.githubusercontent.com/20410193/149573538-8f631c14-a037-4688-9f49-de99be49d8b3.mp4


