### PR TITLE
[REFACTOR] MainTableView DataSource 로직 리팩토링 

### DIFF
--- a/Havit/Havit/Screens/Main/View/Cell/ReachRateNotificationTableViewCell.swift
+++ b/Havit/Havit/Screens/Main/View/Cell/ReachRateNotificationTableViewCell.swift
@@ -92,7 +92,7 @@ final class ReachRateNotificationTableViewCell: BaseTableViewCell {
             .disposed(by: disposeBag)
     }
     
-    func updateNotification(to text: String) {
+    func updateNotificationLabel(to text: String) {
         notificationLabel.text = text
     }
 }

--- a/Havit/Havit/Screens/Main/View/MainTableViewController.swift
+++ b/Havit/Havit/Screens/Main/View/MainTableViewController.swift
@@ -78,6 +78,10 @@ class MainTableViewController: BaseViewController {
     private let searchHeaderView = MainSearchHeaderView()
     
     private var presentableCellTypesInReachSection: [ReachSectionCellType] = []
+    
+    func appendDummyPresentableCells() {
+        presentableCellTypesInReachSection.append(contentsOf: [.notification, .progress])
+    }
 }
 
 extension MainTableViewController: UITableViewDataSource {

--- a/Havit/Havit/Screens/Main/View/MainTableViewController.swift
+++ b/Havit/Havit/Screens/Main/View/MainTableViewController.swift
@@ -16,28 +16,28 @@ class MainTableViewController: BaseViewController {
         static let footerHeight: CGFloat = 122
     }
     
-    private enum ReachSection: Int, CaseIterable {
+    private enum ReachSectionCellType: Int, CaseIterable {
         case notification
         case progress
     }
     
-    private enum CategorySection: Int, CaseIterable {
+    private enum CategorySectionCellType: Int, CaseIterable {
         case category
         case guideline
         case recent
         case recommend
     }
     
-    private enum SectionType: Int, CaseIterable {
+    private enum MainTableViewSectionType: Int, CaseIterable {
         case reach
         case category
         
         var numberOfRows: Int {
             switch self {
             case .reach:
-                return ReachSection.allCases.count
+                return ReachSectionCellType.allCases.count
             case .category:
-                return CategorySection.allCases.count
+                return CategorySectionCellType.allCases.count
             }
         }
         
@@ -89,11 +89,11 @@ class MainTableViewController: BaseViewController {
 
 extension MainTableViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        return SectionType.allCases.count
+        return MainTableViewSectionType.allCases.count
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        let sectionType = SectionType.init(rawValue: section)
+        let sectionType = MainTableViewSectionType.init(rawValue: section)
         guard var rowCount = sectionType?.numberOfRows else { return 0 }
         
         switch sectionType {
@@ -107,11 +107,11 @@ extension MainTableViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let section = SectionType.init(rawValue: indexPath.section)
+        let section = MainTableViewSectionType.init(rawValue: indexPath.section)
         
         switch section {
         case .reach:
-            let row = ReachSection.init(rawValue: indexPath.row)
+            let row = ReachSectionCellType.init(rawValue: indexPath.row)
             guard var rowValue = row?.rawValue else { return UITableViewCell() }
             rowValue = isNotificationDeleted ? rowValue + 1 : rowValue
             
@@ -122,8 +122,8 @@ extension MainTableViewController: UITableViewDataSource {
                 cell.updateNotification(to: "도달률이 50% 이하로 떨어졌어요!")
                 cell.didTapCloseButton = { [weak self] in
                     self?.isNotificationDeleted = true
-                    tableView.deleteRows(at: [IndexPath.init(row: ReachSection.notification.rawValue,
-                                                             section: SectionType.reach.rawValue)],
+                    tableView.deleteRows(at: [IndexPath.init(row: ReachSectionCellType.notification.rawValue,
+                                                             section: MainTableViewSectionType.reach.rawValue)],
                                          with: .fade)
                 }
                 return cell
@@ -149,7 +149,7 @@ extension MainTableViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let section = SectionType.init(rawValue: section)
+        let section = MainTableViewSectionType.init(rawValue: section)
         switch section {
         case .category:
             return searchHeaderView
@@ -159,21 +159,21 @@ extension MainTableViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return SectionType.init(rawValue: section)?.headerHeight ?? .zero
+        return MainTableViewSectionType.init(rawValue: section)?.headerHeight ?? .zero
     }
     
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return SectionType.init(rawValue: section)?.footerView
+        return MainTableViewSectionType.init(rawValue: section)?.footerView
     }
     
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return SectionType.init(rawValue: section)?.footerHeight ?? .zero
+        return MainTableViewSectionType.init(rawValue: section)?.footerHeight ?? .zero
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y
-        let reachSection = SectionType.reach.rawValue
-        let reachSectionHeight = ReachSection.allCases.enumerated().map { (index, _) in
+        let reachSection = MainTableViewSectionType.reach.rawValue
+        let reachSectionHeight = ReachSectionCellType.allCases.enumerated().map { (index, _) in
             tableView.rectForRow(at: IndexPath(row: index, section: reachSection)).height
         }.reduce(CGFloat.zero, +)
         let isScrolledOverReachSection = offsetY >= reachSectionHeight

--- a/Havit/Havit/Screens/Main/View/MainTableViewController.swift
+++ b/Havit/Havit/Screens/Main/View/MainTableViewController.swift
@@ -29,8 +29,8 @@ class MainTableViewController: BaseViewController {
     }
     
     private enum MainTableViewSectionType: Int, CaseIterable {
-        case reach
-        case category
+        case reach = 0
+        case category = 1
         
         var numberOfRows: Int {
             switch self {
@@ -93,7 +93,7 @@ extension MainTableViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        let sectionType = MainTableViewSectionType.init(rawValue: section)
+        let sectionType = MainTableViewSectionType(rawValue: section)
         guard var rowCount = sectionType?.numberOfRows else { return 0 }
         
         switch sectionType {
@@ -107,11 +107,11 @@ extension MainTableViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let section = MainTableViewSectionType.init(rawValue: indexPath.section)
+        let section = MainTableViewSectionType(rawValue: indexPath.section)
         
         switch section {
         case .reach:
-            let row = ReachSectionCellType.init(rawValue: indexPath.row)
+            let row = ReachSectionCellType(rawValue: indexPath.row)
             guard var rowValue = row?.rawValue else { return UITableViewCell() }
             rowValue = isNotificationDeleted ? rowValue + 1 : rowValue
             
@@ -149,7 +149,7 @@ extension MainTableViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let section = MainTableViewSectionType.init(rawValue: section)
+        let section = MainTableViewSectionType(rawValue: section)
         switch section {
         case .category:
             return searchHeaderView
@@ -159,15 +159,15 @@ extension MainTableViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return MainTableViewSectionType.init(rawValue: section)?.headerHeight ?? .zero
+        return MainTableViewSectionType(rawValue: section)?.headerHeight ?? .zero
     }
     
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return MainTableViewSectionType.init(rawValue: section)?.footerView
+        return MainTableViewSectionType(rawValue: section)?.footerView
     }
     
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return MainTableViewSectionType.init(rawValue: section)?.footerHeight ?? .zero
+        return MainTableViewSectionType(rawValue: section)?.footerHeight ?? .zero
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/Havit/Havit/Screens/Main/View/MainTableViewController.swift
+++ b/Havit/Havit/Screens/Main/View/MainTableViewController.swift
@@ -108,7 +108,7 @@ extension MainTableViewController: UITableViewDataSource {
             case .notification:
                 let cell = tableView.dequeueReusableCell(withType: ReachRateNotificationTableViewCell.self,
                                                          for: indexPath)
-                cell.updateNotification(to: "도달률이 50% 이하로 떨어졌어요!")
+                cell.updateNotificationLabel(to: "도달률이 50% 이하로 떨어졌어요!")
                 cell.didTapCloseButton = { [weak self] in
                     self?.presentableCellTypesInReachSection.removeAll { type in
                         type == .notification

--- a/Havit/Havit/Screens/Main/View/MainViewController.swift
+++ b/Havit/Havit/Screens/Main/View/MainViewController.swift
@@ -21,6 +21,7 @@ final class MainViewController: MainTableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        appendDummyPresentableCells()
     }
     
     override func render() {


### PR DESCRIPTION
## 🟣 관련 이슈
- close #97

## 🟣 구현/변경 사항 및 이유

#62 pr 의 tableView DataSource 에 대한 설정이 읽기 어렵고, 로직이 맞지 않는 부분이 있어 리팩토링을 진행했습니다.

## 🟣 PR Point
- 서버 데이터에 따라 아래와 같이 ReachSection 에서 보일 수 있는 cellType 을 append 해줘야겠지만, 
```swift
if response.notificationData != nil {
  presentableCellTypesInReachSection.append(.notification)
}
if response.progressData != nil {
  presentableCellTypesInReachSection.append(.progress)
}

```
우선 데이터 연동이 안되어있기 때문에 `viewDidLoad` 에서 임의로 cellType 들을 넣어주었습니다
```swift
presentableCellTypesInReachSection.append(contentsOf: [.notification, .progress])
```
## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
