### PR TITLE
[FEAT] 웹뷰 읽음 버튼 클릭 이벤트 연결 / push 동작시 tabBar hidden 처리

### DIFF
--- a/Havit/Havit/Screens/Tabbar/View/TabbarController.swift
+++ b/Havit/Havit/Screens/Tabbar/View/TabbarController.swift
@@ -54,7 +54,7 @@ class TabbarController: UITabBarController {
     // MARK: - func
     
     private func render() {
-        self.view.addSubview(addButton)
+        self.tabBar.addSubview(addButton)
         self.addButton.snp.makeConstraints {
             $0.centerX.equalTo(Size.addButtonCenterX)
             $0.centerY.equalTo(tabBar.snp.top)

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -75,6 +75,7 @@ final class WebViewController: BaseViewController {
     init(urlString: String, isReadContent: Bool) {
         viewModel = WebViewModel(urlString: urlString, isReadContent: isReadContent)
         super.init()
+        self.hidesBottomBarWhenPushed = true
     }
 
     @available(*, unavailable)

--- a/Havit/Havit/Screens/WebView/View/WebViewController.swift
+++ b/Havit/Havit/Screens/WebView/View/WebViewController.swift
@@ -72,8 +72,8 @@ final class WebViewController: BaseViewController {
     
     // MARK: - init
     
-    init(urlString: String) {
-        viewModel = WebViewModel(urlString: urlString)
+    init(urlString: String, isReadContent: Bool) {
+        viewModel = WebViewModel(urlString: urlString, isReadContent: isReadContent)
         super.init()
     }
 
@@ -183,6 +183,15 @@ final class WebViewController: BaseViewController {
                 UIApplication.shared.open(url, options: [:])
             }
             .disposed(by: disposeBag)
+        
+        toolbar.checkReadBarButton.rx
+            .tap
+            .map { _ in
+                let isReadFromnetworkResult = true
+                return isReadFromnetworkResult
+            }
+            .bind(to: viewModel.isReadContent)
+            .disposed(by: disposeBag)
     }
     
     private func bindOutput() {
@@ -218,6 +227,15 @@ final class WebViewController: BaseViewController {
             }
             .asDriver(onErrorJustReturn: UIImage())
             .drive(toolbar.forwardBarButton.rx.image)
+            .disposed(by: disposeBag)
+        
+        viewModel.isReadContent
+            .map { isReadContent in
+                let readContentImage = isReadContent ? ImageLiteral.iconContentsRead : ImageLiteral.iconContentsUnread
+                return readContentImage.withRenderingMode(.alwaysOriginal)
+            }
+            .asDriver(onErrorJustReturn: UIImage())
+            .drive(toolbar.checkReadBarButton.rx.image)
             .disposed(by: disposeBag)
     }
 }

--- a/Havit/Havit/Screens/WebView/ViewModel/WebViewModel.swift
+++ b/Havit/Havit/Screens/WebView/ViewModel/WebViewModel.swift
@@ -26,7 +26,7 @@ final class WebViewModel {
         self.urlString = BehaviorSubject<String?>(value: urlString)
         self.canGoBack = BehaviorSubject(value: false)
         self.canGoForward = BehaviorSubject(value: false)
-        self.isReadContent = BehaviorSubject(value: false)
+        self.isReadContent = BehaviorSubject(value: isReadContent)
         
         self.urlRequest = self.urlString
             .compactMap { urlString -> String? in

--- a/Havit/Havit/Screens/WebView/ViewModel/WebViewModel.swift
+++ b/Havit/Havit/Screens/WebView/ViewModel/WebViewModel.swift
@@ -16,15 +16,17 @@ final class WebViewModel {
     let urlString: BehaviorSubject<String?>
     let canGoBack: BehaviorSubject<Bool>
     let canGoForward: BehaviorSubject<Bool>
+    let isReadContent: BehaviorSubject<Bool>
     
     // MARK: - ViewModel -> View
     
     var urlRequest: Observable<URLRequest>
     
-    init(urlString: String) {
+    init(urlString: String, isReadContent: Bool) {
         self.urlString = BehaviorSubject<String?>(value: urlString)
         self.canGoBack = BehaviorSubject(value: false)
         self.canGoForward = BehaviorSubject(value: false)
+        self.isReadContent = BehaviorSubject(value: false)
         
         self.urlRequest = self.urlString
             .compactMap { urlString -> String? in


### PR DESCRIPTION
## 🟣 관련 이슈

- close #142 

## 🟣 구현/변경 사항 및 이유

- 웹뷰 읽음 버튼 클릭 이벤트 연결했습니다
- push 동작시 tabBar hidden 처리했습니다

## 🟣 PR Point
- @YoonAh-dev 아래 부분을 네트워크 통신 성공했을 때, 읽음 여부를 true 나 false 로 변경해주면 됩니다. 감삼다 감삼다 
```
            .map { _ in
                let isReadFromnetworkResult = true
                return isReadFromnetworkResult
            }
```
어떤 분이실지 모르겠지만,, 아마 @beansbin 님,,?? 웹뷰로 들어올때 요렇게 들어오시면 됩니다. 
```
let webViewController = WebViewController(urlString: "www.naver.com", isReadContent: true)
self.navigationController?.pushViewController(webViewController), animated: true)
```
- 근데 지금 영상찍고 나서 보니까 hidesBottomBarWhenPushed 하니까 addButton 이 위로 달라가 붙네여..?ㅎㅎ 음 재밌는 재질~
## 🟣 참고 사항

https://user-images.githubusercontent.com/20410193/150161291-db5bbe86-c916-416b-ae41-241eed11d2be.mp4


