### PR TITLE
[ADD] 최근 저장 콘텐츠 뷰 구현

### DIFF
--- a/Havit/Havit.xcodeproj/project.pbxproj
+++ b/Havit/Havit.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		4FB24FF22792184B00CCDB0C /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4D6F9E2F278C8AA700EC074D /* Pretendard-SemiBold.otf */; };
 		4FB24FF32792184F00CCDB0C /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4D6F9E30278C8AA700EC074D /* Pretendard-Thin.otf */; };
 		ED3502A72798671E0033C280 /* NotSearchedCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3502A62798671E0033C280 /* NotSearchedCollectionViewCell.swift */; };
+		ED3502A927986BE20033C280 /* MainRecentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3502A827986BE20033C280 /* MainRecentViewController.swift */; };
 		ED443EAE278598670059DE76 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443EAD278598670059DE76 /* AppDelegate.swift */; };
 		ED443EB0278598670059DE76 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED443EAF278598670059DE76 /* SceneDelegate.swift */; };
 		ED443EB7278598690059DE76 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED443EB6278598690059DE76 /* Assets.xcassets */; };
@@ -276,6 +277,7 @@
 		4F4DF4ED27943E9D00DD629C /* CategoryEmptyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryEmptyViewController.swift; sourceTree = "<group>"; };
 		4F81AE172797E97D00336AFE /* AddCategoryTitleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCategoryTitleViewController.swift; sourceTree = "<group>"; };
 		ED3502A62798671E0033C280 /* NotSearchedCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotSearchedCollectionViewCell.swift; path = Havit/Screens/Main/View/Component/NotSearchedCollectionViewCell.swift; sourceTree = SOURCE_ROOT; };
+		ED3502A827986BE20033C280 /* MainRecentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainRecentViewController.swift; sourceTree = "<group>"; };
 		ED443EAA278598670059DE76 /* Havit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Havit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED443EAD278598670059DE76 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		ED443EAF278598670059DE76 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -813,6 +815,7 @@
 				ED443F0C2786A2D30059DE76 /* MainViewController.swift */,
 				EDDE099C27908DF40093B83F /* MainTableViewController.swift */,
 				ED87AE5D2798125500517AEC /* MainUnwatchedViewController.swift */,
+				ED3502A827986BE20033C280 /* MainRecentViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1333,7 +1336,7 @@
 				ED3502A72798671E0033C280 /* NotSearchedCollectionViewCell.swift in Sources */,
 				EDE7D6C927937F37009C70EF /* CategoryListTableViewCell.swift in Sources */,
 				EDEF61B82791EABF00C93C84 /* NetworkStatus.swift in Sources */,
-				15D49CE3278F19170030DBE5 /* SortTwoContentsCollectionViewCell.swift in Sources */,
+				15D49CE3278F19170030DBE5 /* CategoryContents2xNCollectionViewCell.swift in Sources */,
 				EDE7D6DE2797E3C7009C70EF /* MainCategoryEmptyView.swift in Sources */,
 				15D49CE3278F19170030DBE5 /* CategoryContents2xNCollectionViewCell.swift in Sources */,
 				ED443F1B2786A3540059DE76 /* CategoryContentsViewModel.swift in Sources */,
@@ -1343,6 +1346,7 @@
 				ED443F1D2786A3FA0059DE76 /* CategoryViewController.swift in Sources */,
 				4DD166FD2796D0C900AD8960 /* CategoryService.swift in Sources */,
 				ED443F2E2786AB8A0059DE76 /* ImageLiteral.swift in Sources */,
+				ED3502A927986BE20033C280 /* MainRecentViewController.swift in Sources */,
 				ED443F312786AC5F0059DE76 /* UIFont+Extension.swift in Sources */,
 				ED443F7A278B61590059DE76 /* UITableView+Extension.swift in Sources */,
 				EDE7D6D027953E2E009C70EF /* MainCategoryPageControl.swift in Sources */,

--- a/Havit/Havit/Screens/Main/View/Cell/RecentContentTableViewCell.swift
+++ b/Havit/Havit/Screens/Main/View/Cell/RecentContentTableViewCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import RxCocoa
 import SnapKit
 
 final class RecentContentTableViewCell: BaseTableViewCell {
@@ -20,6 +21,8 @@ final class RecentContentTableViewCell: BaseTableViewCell {
         }()
         static let cellHeight = 171
     }
+    
+    var didTapOverallButton: (() -> Void)?
     
     // MARK: - property
     
@@ -53,6 +56,18 @@ final class RecentContentTableViewCell: BaseTableViewCell {
     
     private let dummyContents: [String] = []
     
+    // MARK: - init
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        bind()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func render() {
         contentView.addSubViews([titleLabel, overallButton])
         
@@ -74,6 +89,15 @@ final class RecentContentTableViewCell: BaseTableViewCell {
     }
     
     // MARK: - func
+    
+    private func bind() {
+        overallButton.rx.tap
+            .asDriver()
+            .drive(onNext: { [weak self] in
+                self?.didTapOverallButton?()
+            })
+            .disposed(by: disposeBag)
+    }
     
     private func setupContentPartLayout(with contents: [String]) {
         let hasContent = !contents.isEmpty

--- a/Havit/Havit/Screens/Main/View/MainRecentViewController.swift
+++ b/Havit/Havit/Screens/Main/View/MainRecentViewController.swift
@@ -59,7 +59,7 @@ final class MainRecentViewController: BaseViewController {
         super.configUI()
         view.backgroundColor = .white
         setupNavigationBar()
-        setupCollectionViewHiddenState(with: false)
+        setupCollectionViewHiddenState(with: true)
     }
     
     // MARK: - func
@@ -74,7 +74,7 @@ final class MainRecentViewController: BaseViewController {
     }
     
     private func setupNavigationBar() {
-        title = "봐야 하는 콘텐츠"
+        title = "최근 저장 콘텐츠"
         setupBaseNavigationBar(backgroundColor: .havitWhite,
                                titleColor: .primaryBlack,
                                isTranslucent: false,

--- a/Havit/Havit/Screens/Main/View/MainRecentViewController.swift
+++ b/Havit/Havit/Screens/Main/View/MainRecentViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import RxCocoa
 import SnapKit
 
 final class MainRecentViewController: BaseViewController {

--- a/Havit/Havit/Screens/Main/View/MainRecentViewController.swift
+++ b/Havit/Havit/Screens/Main/View/MainRecentViewController.swift
@@ -1,16 +1,15 @@
 //
-//  MainUnwatchedViewController.swift
+//  MainRecentViewController.swift
 //  Havit
 //
-//  Created by SHIN YOON AH on 2022/01/19.
+//  Created by SHIN YOON AH on 2022/01/20.
 //
 
 import UIKit
 
-import RxCocoa
 import SnapKit
 
-final class MainUnwatchedViewController: BaseViewController {
+final class MainRecentViewController: BaseViewController {
     
     private enum Size {
         static let cellWidth: CGFloat = UIScreen.main.bounds.size.width
@@ -35,8 +34,8 @@ final class MainUnwatchedViewController: BaseViewController {
         collectionView.register(cell: ContentsCollectionViewCell.self)
         return collectionView
     }()
-    private let unwatchedEmptyView = MainContentEmptyView(guideText:
-                                                            "봐야 하는 콘텐츠가 없습니다.\n새로운 콘텐츠를 저장해보세요!")
+    private let recentEmptyView = MainContentEmptyView(guideText:
+                                                            "최근에 저장한 콘텐츠가 없습니다.\n새로운 콘텐츠를 저장해 보세요!")
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -44,10 +43,10 @@ final class MainUnwatchedViewController: BaseViewController {
     }
     
     override func render() {
-        view.addSubView(unwatchedEmptyView)
-        unwatchedEmptyView.addSubview(contentCollectionView)
+        view.addSubView(recentEmptyView)
+        recentEmptyView.addSubview(contentCollectionView)
         
-        unwatchedEmptyView.snp.makeConstraints {
+        recentEmptyView.snp.makeConstraints {
             $0.top.leading.trailing.bottom.equalToSuperview()
         }
         
@@ -92,7 +91,7 @@ final class MainUnwatchedViewController: BaseViewController {
     }
 }
 
-extension MainUnwatchedViewController: UICollectionViewDataSource {
+extension MainRecentViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 20
     }

--- a/Havit/Havit/Screens/Main/View/MainRecentViewController.swift
+++ b/Havit/Havit/Screens/Main/View/MainRecentViewController.swift
@@ -59,7 +59,7 @@ final class MainRecentViewController: BaseViewController {
         super.configUI()
         view.backgroundColor = .white
         setupNavigationBar()
-        setupCollectionViewHiddenState(with: true)
+        setupCollectionViewHiddenState(with: false)
     }
     
     // MARK: - func

--- a/Havit/Havit/Screens/Main/View/MainTableViewController.swift
+++ b/Havit/Havit/Screens/Main/View/MainTableViewController.swift
@@ -141,6 +141,10 @@ extension MainTableViewController: UITableViewDataSource {
         case .recent:
             let cell = tableView.dequeueReusableCell(withType: RecentContentTableViewCell.self,
                                                      for: indexPath)
+            cell.didTapOverallButton = { [weak self] in
+                let recentViewController = MainRecentViewController()
+                self?.navigationController?.pushViewController(recentViewController, animated: true)
+            }
             return cell
         case .recommend:
             let cell = tableView.dequeueReusableCell(withType: RecommendSiteTableViewCell.self,


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- close #145 

## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
최근 저장 콘텐츠 뷰를 구현했습니다. 

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
* 봐야 하는 콘텐츠 뷰와 동일하게 생겨서 저번이랑 거의 코드가 동일합니다.
* 콘텐츠 추가 버튼은 차후에 연결할 예정입니다.
* emptyView 확인을 위해서 Boolean값으로 받았는데, 나중에는 배열.count같은 걸로 확인할 예정입니다.

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
![Simulator Screen Recording - iPhone 13 - 2022-01-20 at 01 14 56](https://user-images.githubusercontent.com/55099365/150170787-541db37e-d297-4e61-aa10-fd6cf1114323.gif)

