### PR TITLE
[FEAT] 전체 CategoryView에서 화면 전환 및 Data 전달 

### DIFF
--- a/Havit/Havit/Network/Model/Category.swift
+++ b/Havit/Havit/Network/Model/Category.swift
@@ -11,12 +11,14 @@ struct Category: Decodable {
     let id: Int?
     let title: String?
     let orderIndex: Int?
+    let imageId: Int?
     let imageUrl: String?
 
     enum CodingKeys: String, CodingKey {
         case id
         case title
         case orderIndex
+        case imageId
         case imageUrl = "url"
     }
 }

--- a/Havit/Havit/Screens/Category/View/CategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/CategoryViewController.swift
@@ -164,6 +164,7 @@ class CategoryViewController: BaseViewController {
         editButton.rx.tap
             .bind(onNext: { [weak self] in
                 let manageCategory = ManageCategoryViewController()
+                manageCategory.categories = self?.categories ?? []
                 self?.navigationController?.pushViewController(manageCategory, animated: true)
             })
             .disposed(by: disposeBag)

--- a/Havit/Havit/Screens/Category/View/CategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/CategoryViewController.swift
@@ -12,6 +12,11 @@ import SnapKit
 
 class CategoryViewController: BaseViewController {
 
+    enum BeforeCategoryViewControllerType {
+        case main
+        case tabbar
+    }
+
     // MARK: - property
     let categoryService: CategorySeriviceable = CategoryService(apiService: APIService(),
                                                                 environment: .development)
@@ -74,12 +79,32 @@ class CategoryViewController: BaseViewController {
         return button
     }()
 
+    // MARK: - init
+
+    init(type: BeforeCategoryViewControllerType) {
+        switch type {
+        case .main:
+            backButton.isHidden = false
+        case .tabbar:
+            backButton.isHidden = true
+        }
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     // MARK: - life cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setDelegation()
         getCategory()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        setupBaseNavigationBar(backgroundColor: .white)
     }
 
     func getCategory() {
@@ -155,6 +180,12 @@ class CategoryViewController: BaseViewController {
     }
 
     private func bind() {
+//        addButton.rx.tap
+//            .bind(onNext: { [weak self] in
+//                // 카테고리 추가하는 뷰로 이동 
+//            })
+//            .disposed(by: disposeBag)
+
         backButton.rx.tap
             .bind(onNext: { [weak self] in
                 self?.navigationController?.popViewController(animated: true)

--- a/Havit/Havit/Screens/Category/View/CategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/CategoryViewController.swift
@@ -100,11 +100,11 @@ class CategoryViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setDelegation()
-        getCategory()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         setupBaseNavigationBar(backgroundColor: .white)
+        getCategory()
     }
 
     func getCategory() {

--- a/Havit/Havit/Screens/Category/View/CategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/CategoryViewController.swift
@@ -12,7 +12,7 @@ import SnapKit
 
 class CategoryViewController: BaseViewController {
 
-    enum BeforeCategoryViewControllerType {
+    enum PresentableParentType {
         case main
         case tabbar
     }
@@ -81,7 +81,7 @@ class CategoryViewController: BaseViewController {
 
     // MARK: - init
 
-    init(type: BeforeCategoryViewControllerType) {
+    init(type: PresentableParentType) {
         switch type {
         case .main:
             backButton.isHidden = false

--- a/Havit/Havit/Screens/Category/View/Cell/CategoryCollectionViewCell.swift
+++ b/Havit/Havit/Screens/Category/View/Cell/CategoryCollectionViewCell.swift
@@ -21,6 +21,8 @@ class CategoryCollectionViewCell: BaseCollectionViewCell {
 
     // MARK: - property
 
+    var presentEditCategoryClosure: (() -> Void)? 
+
     private let categoryImageView: UIImageView = {
         let image = UIImageView()
         image.image = ImageLiteral.imgCategoryNone
@@ -49,6 +51,7 @@ class CategoryCollectionViewCell: BaseCollectionViewCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        bind()
     }
 
     @available(*, unavailable)
@@ -116,5 +119,13 @@ class CategoryCollectionViewCell: BaseCollectionViewCell {
             categoryImageView.kf.setImage(with: url)
         }
         categoryTitleLabel.text = data.title
+    }
+
+    private func bind() {
+        editButton.rx.tap
+            .bind(onNext: { [weak self] in
+                self?.presentEditCategoryClosure?()
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/Havit/Havit/Screens/Category/View/EditCategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/EditCategoryViewController.swift
@@ -15,6 +15,11 @@ class EditCategoryViewController: BaseViewController {
 
     // MARK: - property
 
+    var categoryId = 0
+    var titleText = ""
+    var iconImageId = 0
+    var sendData: (() -> Void)?
+
     let categoryService: CategorySeriviceable = CategoryService(apiService: APIService(), environment: .development)
 
     private let titleLabel: UILabel = {
@@ -80,18 +85,35 @@ class EditCategoryViewController: BaseViewController {
         return button
     }()
 
+    // MARK: - init
+
+    init(categoryId: Int, titleText: String, imageId: Int) {
+        self.categoryId = categoryId
+        categoryTitleTextField.text = titleText
+        self.iconImageId = imageId
+
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     // MARK: - life cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setDelegation()
+        print(categoryId)
+        print(iconImageId)
     }
 
     func editCategory() {
         Task {
             do {
-                let categories = try await categoryService.editCategory(categoryId: 3, title: "카테고리 수정", imageId: 2)
+                try await categoryService.editCategory(categoryId: categoryId, title: categoryTitleTextField.text ?? "", imageId: iconImageId)
                 self.makeAlert(title: "카테고리 수정", message: "카테고리 수정 성공", okAction: { [weak self] _ in
+                    self?.sendData?()
                     self?.navigationController?.popViewController(animated: true)
                 })
             } catch APIServiceError.serverError {
@@ -191,6 +213,12 @@ class EditCategoryViewController: BaseViewController {
     }
 }
 
+extension EditCategoryViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        iconImageId = indexPath.row + 1
+    }
+}
+
 extension EditCategoryViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 15
@@ -198,6 +226,14 @@ extension EditCategoryViewController: UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(forIndexPath: indexPath) as CategoryIconCollectionViewCell
+
+        if indexPath.row == iconImageId - 1 {
+            cell.isSelected = true
+            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
+        } else {
+            cell.isSelected = false
+        }
+
         return cell
     }
     

--- a/Havit/Havit/Screens/Category/View/EditCategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/EditCategoryViewController.swift
@@ -89,6 +89,7 @@ class EditCategoryViewController: BaseViewController {
 
     init(categoryId: Int, titleText: String, imageId: Int) {
         self.categoryId = categoryId
+        self.titleText = titleText
         categoryTitleTextField.text = titleText
         self.iconImageId = imageId
 
@@ -104,14 +105,12 @@ class EditCategoryViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setDelegation()
-        print(categoryId)
-        print(iconImageId)
     }
 
     func editCategory() {
         Task {
             do {
-                try await categoryService.editCategory(categoryId: categoryId, title: categoryTitleTextField.text ?? "", imageId: iconImageId)
+                try await categoryService.editCategory(categoryId: categoryId ?? 0, title: categoryTitleTextField.text ?? "", imageId: iconImageId ?? 0)
                 self.makeAlert(title: "카테고리 수정", message: "카테고리 수정 성공", okAction: { [weak self] _ in
                     self?.sendData?()
                     self?.navigationController?.popViewController(animated: true)

--- a/Havit/Havit/Screens/Category/View/EditCategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/EditCategoryViewController.swift
@@ -15,9 +15,9 @@ class EditCategoryViewController: BaseViewController {
 
     // MARK: - property
 
-    var categoryId = 0
-    var titleText = ""
-    var iconImageId = 0
+    var categoryId: Int
+    var titleText: String
+    var iconImageId: Int
     var sendData: (() -> Void)?
 
     let categoryService: CategorySeriviceable = CategoryService(apiService: APIService(), environment: .development)

--- a/Havit/Havit/Screens/Category/View/EditCategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/EditCategoryViewController.swift
@@ -138,6 +138,7 @@ class EditCategoryViewController: BaseViewController {
     }
 
     override func configUI() {
+        view.backgroundColor = .white
         setupBaseNavigationBar(backgroundColor: .havitPurple, titleColor: .white, isTranslucent: false, tintColor: .white)
         setNavigationItem()
         bind()
@@ -167,16 +168,18 @@ class EditCategoryViewController: BaseViewController {
     }
 
     private func bind() {
-        Observable.merge(
-            backButton.rx.tap.map { $0 },
-            doneButton.rx.tap.map { $0 }
-        )
+        backButton.rx.tap
             .bind(onNext: { [weak self] in
-                // donebutton 일때만....
-                self?.editCategory()
+                self?.navigationController?.popViewController(animated: true)
             })
             .disposed(by: disposeBag)
 
+        doneButton.rx.tap
+            .bind(onNext: { [weak self] in
+                self?.editCategory()
+            })
+            .disposed(by: disposeBag)
+        
         categoryTitleTextField.rx.controlEvent([.editingDidBegin])
             .asDriver()
             .drive(onNext: { [weak self] in

--- a/Havit/Havit/Screens/Category/View/EditCategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/EditCategoryViewController.swift
@@ -90,12 +90,14 @@ class EditCategoryViewController: BaseViewController {
     func editCategory() {
         Task {
             do {
-                let categories = try await categoryService.editCategory(categoryId: 18, title: "카테고리 수정", imageId: 2)
+                let categories = try await categoryService.editCategory(categoryId: 3, title: "카테고리 수정", imageId: 2)
                 self.makeAlert(title: "카테고리 수정", message: "카테고리 수정 성공", okAction: { [weak self] _ in
                     self?.navigationController?.popViewController(animated: true)
                 })
-            } catch {
-                print("error")
+            } catch APIServiceError.serverError {
+                print("serverError")
+            } catch APIServiceError.clientError(let message) {
+                print("clientError:\(message)")
             }
         }
     }

--- a/Havit/Havit/Screens/Category/View/ManageCategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/ManageCategoryViewController.swift
@@ -122,11 +122,11 @@ class ManageCategoryViewController: BaseViewController {
             })
             .disposed(by: disposeBag)
 
-        doneButton.rx.tap
-            .bind(onNext: { [weak self] in
-                // changeorder patch 
-            })
-            .disposed(by: disposeBag)
+//        doneButton.rx.tap
+//            .bind(onNext: { [weak self] in
+//                // changeorder patch 
+//            })
+//            .disposed(by: disposeBag)
     }
 
     private func setGesture() {

--- a/Havit/Havit/Screens/Category/View/ManageCategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/ManageCategoryViewController.swift
@@ -176,8 +176,14 @@ extension ManageCategoryViewController: UICollectionViewDataSource {
         cell.configure(type: .manage)
         cell.update(data: categories[indexPath.row])
         cell.presentEditCategoryClosure = {
-            let editCategory = EditCategoryViewController()
-
+            let categoryId = self.categories[indexPath.row].id ?? 0
+            let titleText = self.categories[indexPath.row].title ?? ""
+            let imageId = self.categories[indexPath.row].imageId ?? 0
+            
+            let editCategory = EditCategoryViewController(categoryId: categoryId, titleText: titleText, imageId: imageId)
+            editCategory.sendData = {
+                print("ddd")
+            }
             self.navigationController?.pushViewController(editCategory, animated: true)
         }
         return cell

--- a/Havit/Havit/Screens/Category/View/ManageCategoryViewController.swift
+++ b/Havit/Havit/Screens/Category/View/ManageCategoryViewController.swift
@@ -63,10 +63,6 @@ class ManageCategoryViewController: BaseViewController {
         setGesture()
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        setupBaseNavigationBar(backgroundColor: .white)
-    }
-
     override func render() {
         view.addSubViews([categoryCollectionView, noticeIcon, noticeLabel])
 
@@ -120,12 +116,15 @@ class ManageCategoryViewController: BaseViewController {
     }
 
     private func bind() {
-        Observable.merge(
-            backButton.rx.tap.map { $0 },
-            doneButton.rx.tap.map { $0 }
-        )
+        backButton.rx.tap
             .bind(onNext: { [weak self] in
                 self?.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
+
+        doneButton.rx.tap
+            .bind(onNext: { [weak self] in
+                // changeorder patch 
             })
             .disposed(by: disposeBag)
     }
@@ -176,6 +175,11 @@ extension ManageCategoryViewController: UICollectionViewDataSource {
         
         cell.configure(type: .manage)
         cell.update(data: categories[indexPath.row])
+        cell.presentEditCategoryClosure = {
+            let editCategory = EditCategoryViewController()
+
+            self.navigationController?.pushViewController(editCategory, animated: true)
+        }
         return cell
     }
 


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- close  #121 
## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
 - 전체 카테고리 뷰에서 카테고리 관리 뷰로 데이터 전달
 - 카테고리 관리 뷰 Cell 에서 개별 카테고리 수정 뷰로 데이터 전달
 - 카테고리 관리 뷰 Cell 에서 받은 개별 카테고리 정보를 수정 뷰 api의 request body로 넘겨줍니다.

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

1. 카테고리 수정 후 , alert의 확인 버튼을 누르면 카테고리 관리 뷰에 적용이 되어야하는데 어렵네=요....
2. 다시 전체 카테고리로 돌아왔을때 수정한 카테고리가 서버로부터 다시 get을 해줘야 반영이되는건가여?? 

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

https://user-images.githubusercontent.com/81313960/150196706-d6ec579d-7416-466c-a903-5db22ed60e12.mp4


